### PR TITLE
feat: support namespaces other than minecraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ picked_up, used, mined, broken, crafted 的 <统计内容> 为物品/方块id
 
 custom 的 <统计内容> 详见统计信息的json文件，或 [MC Wiki](https://minecraft.fandom.com/zh/wiki/%E7%BB%9F%E8%AE%A1%E4%BF%A1%E6%81%AF)
 
-上述内容无需带minecraft前缀
+上述内容可省略 `minecraft:` 前缀
 
 [<-uuid>]: 用uuid替换玩家名; (-bot): 统计bot与cam; [<-tell>]: 仅自己可见
 

--- a/stats_helper/__init__.py
+++ b/stats_helper/__init__.py
@@ -199,7 +199,9 @@ def build_scoreboard(source: CommandSource, cls: str, target: str, title: Option
 		title = get_display_text(cls, target)
 	else:
 		title = RTextBase.from_any(title)
-	server.execute('scoreboard objectives add {} minecraft.{}:minecraft.{} {}'.format(constants.ScoreboardName, cls, target, title.to_json_str()))
+	cls_name = "minecraft." + cls if ":" not in cls else cls.replace(":", ".")
+	target_name = "minecraft." + target if ":" not in target else target.replace(":", ".")
+	server.execute('scoreboard objectives add {} {}:{} {}'.format(constants.ScoreboardName, cls_name, target_name, title.to_json_str()))
 	for name, uuid in player_list:
 		value = utils.get_stat_data(uuid, cls, target)
 		if value is not None:

--- a/stats_helper/utils.py
+++ b/stats_helper/utils.py
@@ -26,10 +26,12 @@ def isBot(name: str):
 def get_stat_data(uuid: str, cls: str, target: str) -> Optional[int]:
 	try:
 		with open(os.path.join(Config.get_instance().get_world_path(), 'stats', uuid + '.json'), 'r') as f:
-			target_data: Dict[str, int] = json.load(f)['stats']['minecraft:' + cls]
+			cls_name = "minecraft:" + cls if ":" not in cls else cls
+			target_data: Dict[str, int] = json.load(f)['stats'][cls_name]
 			if target == constants.AllTargetTag:
 				return sum(target_data.values())
-			return target_data['minecraft:' + target]
+			target_name = "minecraft:" + target if ":" not in target else target
+			return target_data[target_name]
 	except:
 		return None
 


### PR DESCRIPTION
现在的代码只能显示统计信息里 `minecraft:` 开头的部分，但如果有其他 mod 的话其他物品/方块/实体的信息也都会记录在同一 json 文件里，个人感觉应该也需要支持读取（至少我有过这个需求）

原有的用法不会改变，`minecraft:` 前缀仍可省略，只是不为其他 namespace 的 id 额外添加前缀而已